### PR TITLE
App names are now full bundles

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -29,9 +29,8 @@ import (
 
 func init() {
 	var (
-		domain  string
-		app     string
-		version string
+		domain string
+		app    string
 	)
 
 	c := &cobra.Command{
@@ -39,7 +38,7 @@ func init() {
 		Short: "Deploy an app",
 		Long: `Deploys an app to a site.
 
-This command tells the node to deploy the app (already uploaded beforehand) with the specific name and version to a site identified by the domain option.
+This command tells the node to deploy the app (already uploaded beforehand) with the specific bundle name to a site identified by the domain option.
 `,
 		DisableAutoGenTag: true,
 
@@ -49,8 +48,7 @@ This command tells the node to deploy the app (already uploaded beforehand) with
 
 			// Request body
 			reqBody := &deployRequestModel{
-				Name:    app,
-				Version: version,
+				Name: app,
 			}
 			buf := new(bytes.Buffer)
 			err := json.NewEncoder(buf).Encode(reqBody)
@@ -80,10 +78,8 @@ This command tells the node to deploy the app (already uploaded beforehand) with
 	// Flags
 	c.Flags().StringVarP(&domain, "domain", "d", "", "primary domain name (required)")
 	c.MarkFlagRequired("domain")
-	c.Flags().StringVarP(&app, "app", "a", "", "app's bundle name (required)")
+	c.Flags().StringVarP(&app, "app", "a", "", "app bundle (required)")
 	c.MarkFlagRequired("app")
-	c.Flags().StringVarP(&version, "version", "v", "", "app's bundle version (required)")
-	c.MarkFlagRequired("version")
 
 	// Add shared flags
 	addSharedFlags(c)

--- a/cmd/upload-app.go
+++ b/cmd/upload-app.go
@@ -300,6 +300,8 @@ When using ` + "`" + `--no-signature` + "`" + `, stkcli will not calculate the c
 					return
 				}
 			}
+
+			fmt.Println("Done:", bundleName)
 		},
 	}
 	uploadCmd.AddCommand(c)

--- a/cmd/zz_formatters.go
+++ b/cmd/zz_formatters.go
@@ -31,8 +31,8 @@ func siteGetResponseModelFormat(m *siteGetResponseModel) (result string) {
 	}
 
 	app := "\033[2m<nil>\033[0m"
-	if m.App != nil {
-		app = fmt.Sprintf("%s-%s", m.App.Name, m.App.Version)
+	if m.App != nil && m.App.Name != "" {
+		app = m.App.Name
 	}
 
 	tlsCert := "\033[2m<nil>\033[0m"

--- a/cmd/zz_models.go
+++ b/cmd/zz_models.go
@@ -80,8 +80,7 @@ type siteSetRequestModel struct {
 // GET /site/<domain> (site get)
 type siteGetResponseModelApp struct {
 	// App details
-	Name    string `json:"name" binding:"required"`
-	Version string `json:"version" binding:"required"`
+	Name string `json:"name"`
 }
 type siteGetResponseModel struct {
 	Domain  string                   `json:"domain"`
@@ -95,14 +94,12 @@ type siteListResponseModel []siteGetResponseModel
 
 // POST /site/<domain>/deploy (deploy app)
 type deployRequestModel struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name string `json:"name"`
 }
 
 // POST /uploadauth (request Azure Storage SAS token)
 type uploadAuthRequestModel struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name string `json:"name"`
 }
 type uploadAuthResponseModel struct {
 	ArchiveURL   string `json:"archiveUrl"`

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -66,9 +66,27 @@ func FileExists(path string) (bool, error) {
 	return true, nil
 }
 
+// FolderExists returns true if the path exists on disk and it's a folder
+func FolderExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		// Ignore the error if it's a "not exists", that's the goal
+		if os.IsNotExist(err) {
+			err = nil
+		}
+		return false, err
+	}
+	if info.IsDir() {
+		// Exists and it's a folder
+		return true, nil
+	}
+	// Exists, but not a folder
+	return false, nil
+}
+
 // EnsureFolder creates a folder if it doesn't exist already
 func EnsureFolder(path string) error {
-	exists, err := PathExists(path)
+	exists, err := FolderExists(path)
 	if err != nil {
 		return err
 	} else if !exists {

--- a/utils/tar.go
+++ b/utils/tar.go
@@ -29,7 +29,7 @@ import (
 )
 
 // TarBZ2 creates a tar.bz2 archive from a folder
-// Source: https://medium.com/@skdomino/taring-untaring-files-in-go-6b07cf56bc07
+// Adapted from: https://gist.github.com/sdomino/e6bc0c98f87843bc26bb
 func TarBZ2(src string, writers ...io.Writer) error {
 	// Ensure the src actually exists before trying to tar it
 	if _, err := os.Stat(src); err != nil {


### PR DESCRIPTION
Companion to https://github.com/Statiko-dev/Statiko/pull/11

Additionally, fixes multiple bugs with tar.bz2 archive creation:

1. Ensure that we're compressing a folder and not a single file
2. Files which have the same name as the folder they're in aren't causing issues anymore
3. Archives now extract without errors on macOS too
4. Other fixes